### PR TITLE
Fix quality movement and some refactoring

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,13 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.3.8
+Date: 05/07/2025
+  Changes:
+    - Updated the quality movement algorithm.
+    - The early quality filter setting now takes the latest quality from the provided list—qualities up to it will be unlocked by the selected technology.
+    - Refactored log calls in debug mode.
+  Bugfixes:
+    - Fixed an issue where a technology with a legendary-quality prerequisite incorrectly received an epic-quality prerequisite after both quality-related technologies were removed.
+---------------------------------------------------------------------------------------------------
 Version: 1.3.7
 Date: 22/03/2025
   Features:

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -269,15 +269,11 @@ end
 
 local MachineTypes = {"crafting-machine", "furnace", "assembling-machine", "mining-drill", "rocket-silo"}
 
-if config("dev-mode") then
-    log("Initiating more operations on automated crafting.")
-end
+LogWrap("Initiating more operations on automated crafting.")
 for _,MachineType in pairs(MachineTypes) do
     if data.raw[MachineType] ~= nil then
         for j,Machine in pairs(data.raw[MachineType]) do
-            if config("dev-mode") then
-                log("Re-scanning Machine \"" .. Machine.name .. "\" now.")
-            end
+            LogWrap("Re-scanning Machine \"" .. Machine.name .. "\" now.")
 
             if string.find(Machine.name, "qa_") then
 

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -8,6 +8,9 @@ end
 
 -- Splits a string by a pattern.
 function Split(str, delim, maxNb)
+    if not str then
+        return {}
+    end
     if string.find(str, delim) == nil then
         return { str }
     end
@@ -32,130 +35,230 @@ function Split(str, delim, maxNb)
     return result
 end
 
--- Add all qualities to the selected Technology, and remove technologies with no effect.
--- Thank you, wvlad for providing me with this new effect movement and technology removal system. (If I ever add a supporters list, you'll be on it!)
-local QualityTechnologyName = config("quality-unlock")
-if config("dev-mode") then
-    log("Adding Qualities to \"".. QualityTechnologyName .."\" Technology.")
-end
-local RemovedTechnologies = {}
-for i,Technology in pairs(data.raw["technology"]) do
-    if config("dev-mode") then
-        log("Scanning Technology \"" .. Technology.name .. "\" now.")
+local EnableLog = config("dev-mode")
+function LogWrap(str)
+    if EnableLog then
+        log(str)
     end
-    if Technology.name ~= QualityTechnologyName then
-        if Technology.effects ~= nil then
-            if config("dev-mode") then
-                log("Technology has Effects.")
-            end
-            local moved = false
-            for j,Effect in pairs(Technology.effects) do
-                if config("dev-mode") then
-                    log("Scanning Modifier of type \"" .. Effect.type .. "\" now.")
-                end
+end
+
+function ListToString(List)
+    local result = {}
+    if List ~= nil then
+        for _,Effect in pairs(List) do
+            if Effect.name ~= nil then
+                table.insert(result, Effect.name)
+            elseif Effect.type ~= nil then
                 if Effect.type == "unlock-quality" then
-                    if config("dev-mode") then
-                        log("Effect is a match! Testing for quality forward movement now.")
-                    end
-                    local EarlyQualityFilter = config("early-quality-filter")
-                    local MoveQuality = true
-                    if EarlyQualityFilter ~= "" then
-                        MoveQuality = false
-                        for _,EarlyQuality in pairs(Split(EarlyQualityFilter, ",%w*")) do
-                            if string.lower(Effect.quality) == string.lower(EarlyQuality) then
-                                MoveQuality = true
-                            end
-                        end
-                    end
-                    if QualityTechnologyName == "rocket-silo" or QualityTechnologyName == "quality-module-2" or QualityTechnologyName == "quality-module-3" then
-                        if Effect.quality == "uncommon" or Effect.quality == "rare" then
-                            MoveQuality = false
-                            if config("dev-mode") then
-                                log("Moving this quality to the \"" .. QualityTechnologyName .. "\" technology would cause the \"" .. Effect.quality .. "\" quality to be moved forward instead of backward! Cancelling this effect movement.")
-                            end
-                        end
-                    end
-                    if MoveQuality then
-                        if config("dev-mode") then
-                            log("Moving quality unlock for quality \"" .. Effect.quality .. "\" to the \"" .. QualityTechnologyName .. "\" technology.")
-                        end
-                        table.insert(data.raw["technology"][QualityTechnologyName].effects, Effect)
-                        data.raw["technology"][i].effects[j] = nil
-                        moved = true
-                        if config("dev-mode") then
-                            log("Effect moved.")
-                        end
-                    end
+                    table.insert(result, "quality:" .. Effect.quality)
+                elseif Effect.type == "unlock-recipe" then
+                    table.insert(result, "recipe:" .. Effect.recipe)
+                else
+                    table.insert(result, "\"" .. Effect.type .. "\"")
                 end
+            else
+                table.insert(result, serpent.block(Effect))
             end
+        end
+    end
+    return table.concat(result, ", ")
+end
 
-            if moved then
-                local function CleanNils(t)
-                  local ans = {}
-                  for _,v in pairs(t) do
-                    ans[ #ans+1 ] = v
-                  end
-                  return ans
-                end
 
-                if Technology.effects ~= nil then 
-                    Technology.effects = CleanNils(Technology.effects)
-                end
+local function CleanNils(t)
+    local ans = {}
+    for _,v in pairs(t) do
+      ans[ #ans+1 ] = v
+    end
+    return ans
+end
 
-                if Technology.effects == nil or #Technology.effects == 0 then
-                    if config("dev-mode") then
-                        log("All effects of Technology \"" .. Technology.name .. "\" have been removed. Removing Technology.")
-                    end
-                    RemovedTechnologies[Technology.name] = Technology
-                    data.raw["technology"][i] = nil
-                end
-            end
+local function NotEmpty(f)
+    return f ~= nil and f ~= {} and f ~= ""
+end
+
+local Technologies = data.raw["technology"]
+local Qualities = data.raw["quality"]
+
+-- Build Prerequisites table so we can do a fast update of tech dependencies:
+-- key is a prerequisite for every tech in value list
+local Prerequisites = {}
+for i,Technology in pairs(Technologies) do
+    -- log("Tech tree " .. i .. " " .. serpent.block(Technology))
+    Prerequisites[Technology.name] = {}
+end
+for i,Technology in pairs(Technologies) do
+    if type(Technology) == "table" and type(Technology.prerequisites) == "table" then
+        for _,Prerequisite in pairs(Technology.prerequisites) do
+            table.insert(Prerequisites[Prerequisite], Technology.name)
         end
     end
 end
-for i,Technology in pairs(data.raw["technology"]) do
-    if config("dev-mode") then
-        log("Scanning technology \"" .. Technology.name .. "\" now.")
+
+-- Build Order table with property:
+-- if TechA depends on TechB, then Order[TechA] > Order[TechB]
+-- It is used in MoveQualities function to check that 
+--  we won't move quality unlocks to later technologies
+local Order = {}
+function UpdateOrder(Tech)
+    local Technology, Name
+    if type(Tech) == "table" then
+        Technology = Tech
+        Name = Tech.name
+    else
+        Technology = Technologies[Tech]
+        Name = Tech
     end
-    if Technology ~= nil then
-        for _,RemovedTechnology in pairs(RemovedTechnologies) do
-            if config("dev-mode") then
-                log("Scanning removed technology \"" .. Technology.name .. "\" now.")
+    if Order[Name] > 0 then
+        -- Order was initialized
+        return Order[Name]
+    end
+    if type(Technology.prerequisites) == "table" then
+        local max = 0
+        for _,Prerequisite in pairs(Technology.prerequisites) do
+            local order = UpdateOrder(Prerequisite)
+            if order + 1 > max then
+                max = order + 1
             end
-            if Technology.prerequisites ~= nil and Technology.prerequisites ~= {} and Technology.prerequisites ~= "" then
-                if config("dev-mode") then
-                    log("Existing technology has dependencies.")
-                end
-                for j,TechnologyDependency in pairs(Technology.prerequisites) do
-                    if config("dev-mode") then
-                        log("Scanning dependency \"" .. TechnologyDependency .. "\" now.")
-                    end
-                    if TechnologyDependency == RemovedTechnology.name then
-                        if config("dev-mode") then
-                            log("Dependency is a match! Replacing dependency for removed technology \"" .. RemovedTechnology.name .. "\" with the dependencies of that technology.")
+        end
+        Order[Name] = max
+    end
+    return Order[Name]
+end
+
+for i,Technology in pairs(Technologies) do
+    Order[Technology.name] = 0
+end
+for Name,Val in pairs(Order) do
+    if Val == 0 then
+        UpdateOrder(Name)
+    end
+end
+
+-- Add all qualities to the selected Technology, and remove quality technologies with no effect.
+-- Thank you, wvlad for providing me with this new effect movement and technology removal system. (If I ever add a supporters list, you'll be on it!)
+-- Updated by A.Freeman
+
+-- Technology that will unlock qualities
+local QualityTechnologyName = config("quality-unlock")
+local QualityTechOrder = Order[QualityTechnologyName]
+-- If not empty, pick a quality with the highest level - all qualities up to that will be unlocked by the abovementioned technology
+local EarlyQualityFilter = Split(config("early-quality-filter"), ",%w*")
+local EarlyQualityLevel = 0
+local EarlyQualityName = nil
+LogWrap("EarlyQualityFilter string: " .. config("early-quality-filter") .. " filter: " .. serpent.block(EarlyQualityFilter))
+for i,Name in pairs(EarlyQualityFilter) do
+    local name = string.lower(Name)
+    if Qualities[name] ~= nil and EarlyQualityLevel < Qualities[name].level then
+        EarlyQualityLevel = Qualities[name].level
+        EarlyQualityName = name
+    end
+end
+if EarlyQualityLevel == 0 then
+    EarlyQualityLevel = 100500 -- aka infinity :D
+end
+
+function MoveQualities(Technology)
+    if type(Technology) ~= "table" or type(Technology.effects) ~= "table" then
+        return false
+    end
+    if Technology.name == QualityTechnologyName then
+        return false
+    end
+    local Moved = false
+    TechOrder = Order[Technology.name]
+    for j,Effect in pairs(Technology.effects) do
+        -- Effect unlocks quality
+        -- Quality Technology order is lower than the current technology's 
+        -- Check if the current quality level is <= EarlyQualityLevel
+        if Effect.type == "unlock-quality" then
+            if QualityTechOrder <= TechOrder and Qualities[Effect.quality].level <= EarlyQualityLevel then
+                table.insert(Technologies[QualityTechnologyName].effects, Effect)
+                Technology.effects[j] = nil
+                Moved = true
+                LogWrap("Moved quality \"" .. Effect.quality .. "\" to Technology \"" .. QualityTechnologyName .. "\"")
+            else
+                local Values = table.concat({tostring(QualityTechOrder), tostring(TechOrder), tostring(Qualities[Effect.quality].level), tostring(EarlyQualityLevel)}, " ")
+                if QualityTechOrder <= TechOrder and Qualities[EarlyQualityName] and Qualities[EarlyQualityName].next == Effect.quality then
+                    -- QualityTechnology unlocks all qualities up to EarlyQuality 
+                    -- But Technology unlocks the next quality of EarlyQuality 
+                    -- So add QualityTechnology as prerequisite to Technology
+                    local Contains = false
+                    for _,Prerequisite in pairs(Technology.prerequisites) do
+                        if Prerequisite == QualityTechnologyName then
+                            Contains = true
                         end
-                        table.remove(data.raw["technology"][i].prerequisites, j)
-                        if RemovedTechnology.prerequisites ~= nil and RemovedTechnology.prerequisites ~= {} and RemovedTechnology.prerequisites ~= "" then
-                            for _,RemovedTechnologyDependency in pairs(RemovedTechnology.prerequisites) do
-                                local AddDependency = true
-                                for k,OtherTechnologyDependency in pairs(Technology.prerequisites) do
-                                    if OtherTechnologyDependency == RemovedTechnologyDependency then
-                                        AddDependency = false
-                                    end
-                                end
-                                if AddDependency then
-                                    if config("dev-mode") then
-                                        log("Adding dependency \"" .. RemovedTechnologyDependency .. "\" to technology \"" .. Technology.name .. "\" now.")
-                                    end
-                                    table.insert(data.raw["technology"][i].prerequisites, RemovedTechnologyDependency)
-                                end
-                            end
-                        end
                     end
+                    if not Contains then
+                        table.insert(Technology.prerequisites, QualityTechnologyName)
+                        table.insert(Prerequisites[QualityTechnologyName], Technology.name)
+                        LogWrap("Skipped quality \"" .. Effect.quality .. "\" with order/level values: " .. Values)
+                        LogWrap("Added prerequisite \"" .. QualityTechnologyName .. "\" to Technology \"" .. Technology.name .. "\"")
+                    end
+                else
+                    LogWrap("Skipped quality \"" .. Effect.quality .. "\" because of wrong order/level values: " .. Values)
                 end
             end
         end
     end
+    if Moved and Technology.effects ~= nil then
+        Technology.effects = CleanNils(Technology.effects)
+    end
+    return Moved
+end
+
+LogWrap("Adding Quality unlocks to \"".. QualityTechnologyName .."\" technology.")
+-- TechnologiesToBeRemoved is a table that will contain TechName:Tech pairs
+local TechnologiesToBeRemoved = {}
+for i,Technology in pairs(data.raw["technology"]) do
+    if Technology.name ~= QualityTechnologyName then
+        LogWrap("Technology \"" .. Technology.name .. "\" has effects: " .. ListToString(Technology.effects))
+        if MoveQualities(Technology) then
+            if Technology.effects == nil or #Technology.effects == 0 then
+                LogWrap("All effects of Technology \"" .. Technology.name .. "\" have been moved.")
+                TechnologiesToBeRemoved[Technology.name] = Technology
+            end
+        end
+    
+    end
+end
+
+-- Update technology dependencies
+--
+-- Prerequisite is to be removed
+-- Tech has Prerequisite in Tech.prerequisites
+-- Remove Prerequisite from Tech.prerequisites
+-- Add Prerequisite.prerequisites to Tech.Prerequisites
+-- Remove Prerequisite technology
+LogWrap("Technologies to be removed: " .. ListToString(TechnologiesToBeRemoved))
+for PrerequisiteName,Prerequisite in pairs(TechnologiesToBeRemoved) do
+    -- Prerequisite is to be removed
+    for _,TechName in pairs(Prerequisites[PrerequisiteName]) do
+        -- Tech has Prerequisite in Tech.prerequisites
+        Tech = data.raw["technology"][TechName]
+        local AddDependencies = {}
+        for p,TechPrerequisiteName in pairs(Tech.prerequisites) do
+            if TechPrerequisiteName == PrerequisiteName then
+                -- Remove Prerequisite from Tech.prerequisites
+                table.remove(Tech.prerequisites, p)
+                -- Add dependencies from Prerequisite to Tech
+                if NotEmpty(Prerequisite.prerequisites) then
+                    for _,AddDependencyName in pairs(Prerequisite.prerequisites) do
+                        table.insert(AddDependencies, AddDependencyName)
+                    end
+                end
+            end
+        end
+        -- Add dependencies from Prerequisite to Tech
+        for _, AddDependency in pairs(AddDependencies) do
+            table.insert(Tech.prerequisites, AddDependency)
+            table.insert(Prerequisites[AddDependency], Tech.name)
+            -- Compatibility fix for Infinite Quality Tiers
+            Tech.enabled = true
+        end
+    end
+    -- Remove Prerequisite technology
+    data.raw["technology"][PrerequisiteName] = nil
 end
 
 local function NAMSModifications(Machine)

--- a/data.lua
+++ b/data.lua
@@ -8,6 +8,13 @@ local function config(name)
     return nil
 end
 
+local EnableLog = config("dev-mode")
+function LogWrap(str)
+    if EnableLog then
+        log(str)
+    end
+end
+
 -- A list of entity names to be skipped over when creating AMS machines.
 local AMSBlocklist = {"awesome-sink-gui"}
 
@@ -59,23 +66,17 @@ end
 local function AddQuality(Machine)
     -- Increase quality for a machine.
     if not config("base-quality") then
-        if config("dev-mode") then
-            log("Base Quality setting is disabled. Skipping.")
-        end
+        LogWrap("Base Quality setting is disabled. Skipping.")
         return Machine
     end
 
     if not config("moduleless-quality") then
         if Machine.module_slots == nil then
-            if config("dev-mode") then
-                log("Moduleless Quality setting is disabled, and this machine doesn't have module slots. Skipping.")
-            end
+            LogWrap("Moduleless Quality setting is disabled, and this machine doesn't have module slots. Skipping.")
             return Machine
         else
             if Machine.module_slots == 0 then
-                if config("dev-mode") then
-                    log("Moduleless Quality setting is disabled, and this machine doesn't have module slots. Skipping.")
-                end
+                LogWrap("Moduleless Quality setting is disabled, and this machine doesn't have module slots. Skipping.")
                 return Machine
             end
         end
@@ -87,20 +88,14 @@ local function AddQuality(Machine)
             if Machine.effect_receiver.base_effect then
                 if Machine.effect_receiver.base_effect.quality then
                     if Machine.effect_receiver.base_effect.quality == 0 then
-                        if config("dev-mode") then
-                            log("Machine does not contain base quality. Adding base quality.")
-                        end
+                        LogWrap("Machine does not contain base quality. Adding base quality.")
                         Machine.effect_receiver.base_effect.quality = config("base-quality-value") / 100 / NormalProbability
                     else
-                        if config("dev-mode") then
-                            log("Machine contains base quality of amount " .. Machine.effect_receiver.base_effect.quality or 0 ..". Skipping.")
-                        end
+                        LogWrap("Machine contains base quality of amount " .. Machine.effect_receiver.base_effect.quality or 0 ..". Skipping.")
                     end
                     BaseQuality = true
                 else
-                    if config("dev-mode") then
-                        log("Machine does not contain base quality. Preparing to add base quality.")
-                    end
+                    LogWrap("Machine does not contain base quality. Preparing to add base quality.")
                     Machine.effect_receiver.base_effect.quality = 0
                 end
             else
@@ -168,9 +163,7 @@ end
 -- Perform operations on automated crafting.
 local MachineTypes = {"crafting-machine", "furnace", "assembling-machine", "mining-drill", "rocket-silo"}
 
-if config("dev-mode") then
-    log("Performing operations on Automated Crafting.")
-end
+LogWrap("Performing operations on Automated Crafting.")
 for _,MachineType in pairs(MachineTypes) do
     if data.raw[MachineType] then
         for j,Machine in pairs(data.raw[MachineType]) do
@@ -199,9 +192,7 @@ for _,MachineType in pairs(MachineTypes) do
             end
 
             if MachineType == "rocket-silo" then
-                if config("dev-mode") then
-                    log("Checking for rocket silo \"" .. Machine.name .. "\" for being banned from Unfixed Rocket Silo Recipes.")
-                end
+                LogWrap("Checking for rocket silo \"" .. Machine.name .. "\" for being banned from Unfixed Rocket Silo Recipes.")
                 if data.raw["recipe"][Machine.fixed_recipe] and data.raw["recipe"][Machine.fixed_recipe].ingredients == {} then
                     UnfixedRSRBanned = true
                 end
@@ -238,9 +229,7 @@ for _,MachineType in pairs(MachineTypes) do
 
             -- Create a new version of all machines which don't have additional module slots.
             if ( not string.find(Machine.name, "qa_") ) and config("ams-machines-toggle") and ( not AMSBanned ) and (config("enable-ams-" .. MachineType)) then
-                if config("dev-mode") then
-                    log("Creating AMS version of \"" .. Machine.name .. "\" now.")
-                end
+                LogWrap("Creating AMS version of \"" .. Machine.name .. "\" now.")
                 local AMSMachine = table.deepcopy(Machine)
                 AMSMachine.name = "qa_" .. AMSMachine.name .. "-ams"
                 AMSMachine = Localiser(AMSMachine, Machine)
@@ -324,9 +313,7 @@ for _,MachineType in pairs(MachineTypes) do
 
                 if AMSMachineRecipe.ingredients[1]["name"] == nil then
                     AMSMachineRecipe.ingredients[1]["name"] = "electronic-circuit"
-                    if config("dev-mode") then
-                        log("Had to replace ingredient name for \"" .. AMSMachineRecipe.name .. "\"")
-                    end
+                    LogWrap("Had to replace ingredient name for \"" .. AMSMachineRecipe.name .. "\"")
                 end
 
                 AMSMachineRecipe.results = {{type = "item", name = AMSMachineItem.name, amount = 1}}
@@ -374,12 +361,10 @@ for _,MachineType in pairs(MachineTypes) do
                 AMSMachineTechnology.effects = {{type = "unlock-recipe", recipe = AMSMachineRecipe.name}}
                 AMSMachineTechnology = Localiser(AMSMachineTechnology, Machine)
 
-                if config("dev-mode") then
-                    log("Made AMS version of \"" .. Machine.name .. "\".")
-                end
+                LogWrap("Made AMS version of \"" .. Machine.name .. "\".")
                 data:extend{AMSMachine, AMSMachineItem, AMSMachineRecipe, AMSMachineTechnology}
-            elseif config("dev-mode") then
-                log("Machine \"" .. Machine.name .. "\" is an AMS machine, AMS machines are turrend off, or this machine is banned. Skipping the AMS machine making process.")
+            else
+                LogWrap("Machine \"" .. Machine.name .. "\" is an AMS machine, AMS machines are turrend off, or this machine is banned. Skipping the AMS machine making process.")
             end
         end
     end
@@ -387,9 +372,7 @@ end
 
 if config("relabeler") then
     -- The relabeler, decreases the quality of an item by 1 tier. Does nothing to normal quality items.
-    if config("dev-mode") then
-        log("Creating machine \"qa_relabeler\"")
-    end
+    LogWrap("Creating machine \"qa_relabeler\"")
     local RelabelerMachine = table.deepcopy(data.raw["furnace"]["recycler"])
     RelabelerMachine.name = "qa_relabeler"
     RelabelerMachine.crafting_categories = {"relabeling"}
@@ -425,9 +408,7 @@ end
 
 if config("upcycler") then
     -- The upcycler, has a chance to increase the quality of an item by 1 tier, as well as chances to leave the item as-is and turn the item into scrap.
-    if config("dev-mode") then
-        log("Creating machine \"qa_upcycler\"")
-    end
+    LogWrap("Creating machine \"qa_upcycler\"")
 end
 
 -- Allow Quality Modules in Beacons.
@@ -438,18 +419,12 @@ if config("quality-beacons") then
 end
 
 -- Improve power of all quality modules.
-if config("dev-mode") then
-    log("Improving power of all quality modules.")
-end
+LogWrap("Improving power of all quality modules.")
 for _,Module in pairs(data.raw["module"]) do
-    if config("dev-mode") then
-        log("Scanning module \"" .. Module.name .. "\" now.")
-    end
+    LogWrap("Scanning module \"" .. Module.name .. "\" now.")
     if Module.effect.quality then
         if Module.effect.quality >= 0 then
-            if config("dev-mode") then
-                log("Module \"" .. Module.name .. "\" contians a Quality increase. Increasing bonus.")
-            end
+            LogWrap("Module \"" .. Module.name .. "\" contians a Quality increase. Increasing bonus.")
             Module.effect.quality = Module.effect.quality * config("quality-module-multiplier")
         end
     end

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "QualityAssurance",
-    "version": "1.3.7",
+    "version": "1.3.8",
     "title": "Quality Assurance",
     "author": "BCC",
     "factorio_version": "2.0",


### PR DESCRIPTION
I started with an attempt to fix [issue with the Lignumis planet mod](https://mods.factorio.com/mod/QualityAssurance/discussion/6748bb9926e562ccc06dc112), but ended up with refactoring of the quality movement algorithm. I tested it a bit with several quality mods (including compatibility fix for Infinite Quality Tiers) besides  Lignumis planet. 

Changes:

- Updated the quality movement algorithm.
- The early quality filter setting now takes the latest quality from the provided list - qualities up to it will be unlocked by the selected technology.
- Refactored log calls in debug mode.

Bugfixes:

- Fixed an issue where a technology with a legendary-quality prerequisite incorrectly received an epic-quality prerequisite after both quality-related technologies were removed.